### PR TITLE
Lint and spellcheck

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,12 @@
+name: Lint
+on: [push, pull_request]
+jobs:
+  black:
+    name: Python Code Format Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Black Code Format Check
+        uses: lgeiger/black-action@master
+        with:
+          args: ". --check --fast --diff"

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,27 +1,12 @@
 # Thanks to the Code Spell Checker team for the example workflow
 name: SpellCheck
 on: [push, pull_request]
-
 jobs:
-  build:
+  SpellCheck:
+    name: Check for spelling errors
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        emacs_version:
-          - 25.3
     steps:
-    - uses: purcell/setup-emacs@master
-      with:
-        version: ${{ matrix.emacs_version }}
-
-    - uses: actions/checkout@v2
-
-    - name: Print emacs version
-      run: emacs --version
-
-    - name: Install dependency
-      run: sudo apt install aspell aspell-en
-
-    - name: Run tests
-      run: make test
+      - uses: actions/checkout@v3
+      - uses: codespell-project/actions-codespell@master
+        with:
+          check_filenames: true

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,12 +1,27 @@
 # Thanks to the Code Spell Checker team for the example workflow
 name: SpellCheck
 on: [push, pull_request]
+
 jobs:
-  SpellCheck:
-    name: Check for spelling errors
+  build:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        emacs_version:
+          - 25.3
     steps:
-      - uses: actions/checkout@v3
-      - uses: codespell-project/actions-codespell@master
-        with:
-          check_filenames: true
+    - uses: purcell/setup-emacs@master
+      with:
+        version: ${{ matrix.emacs_version }}
+
+    - uses: actions/checkout@v2
+
+    - name: Print emacs version
+      run: emacs --version
+
+    - name: Install dependency
+      run: sudo apt install aspell aspell-en
+
+    - name: Run tests
+      run: make test

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,0 +1,12 @@
+# Thanks to the Code Spell Checker team for the example workflow
+name: SpellCheck
+on: [push, pull_request]
+jobs:
+  SpellCheck:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: codespell-project/actions-codespell@master
+        with:
+          check_filenames: true

--- a/src/tests/tests.py
+++ b/src/tests/tests.py
@@ -2,6 +2,7 @@
   Here we can test individual modules and methods.
 """
 
+
 def test_garbage():
     """
     This is a test method, it is not testing anything.


### PR DESCRIPTION
# Lint and spellcheck
Solves : #8 , We need to ensure inner quality. To make this easier for us I recomend linting the code on push to the repo, this ensures that all code atleast follows the black standard. 


## Status of pull request
- [x] Implement [Liniting CI](https://github.com/ivario123/NGAC_ABE/blob/lint_and_spellcheck/.github/workflows/lint.yml)
- [x] Implement [spelling CI](https://github.com/ivario123/NGAC_ABE/blob/lint_and_spellcheck/.github/workflows/spellcheck.yml)

## How did you test your solution?
I ran the test suite, see run [linting 2](https://github.com/ivario123/NGAC_ABE/actions/runs/3412088734), [linting 1](https://github.com/ivario123/NGAC_ABE/actions/runs/3412054303) and [spellcheck 1](https://github.com/ivario123/NGAC_ABE/actions/runs/3412054295/jobs/5677058258).

This includes a lint case that fails and one that passes.


Closes #8 